### PR TITLE
Fix for synchronous rendering failure due to change in node.js child_process API

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,11 +34,11 @@ exports.render = function (str, options, locals) {
   }
 
   // Spawn a browserify process synchronously
-  const output = cp.execSync(
-    `node ${browserifyPath} text ${stringifyForCli(str)} ${stringifyForCli(options)}`
+  const o = cp.spawnSync(
+    'node', [browserifyPath, 'text', stringifyForCli(str), stringifyForCli(options)]
   )
 
-  return output.toString()
+  return o.output.toString()
 }
 
 exports.renderAsync = function (str, options, locals) {


### PR DESCRIPTION
The node.js child_process API appears to have changed.  ``child_process.execSync()`` now uses the system shell by default.  This causes problems with the command line arguments for synchronous renders in jstransformer-browserify and makes it fail under pug.

This PR uses ``child_process.spawnSync()`` which does not use the shell by default.

Note, this is also a security issue.  A malicious file imported using jstransformer-browserify could execute arbitrary commands via the shell.